### PR TITLE
Auto codebook

### DIFF
--- a/.yarn/versions/cd1fc2c3.yml
+++ b/.yarn/versions/cd1fc2c3.yml
@@ -1,0 +1,8 @@
+releases:
+  "@datashaper/app-framework": patch
+  "@datashaper/webapp": patch
+  "@datashaper/workflow": patch
+
+declined:
+  - "@datashaper/react"
+  - "@datashaper/stories"

--- a/javascript/app-framework/src/components/app/ResourcesPane/ResourcesPane.types.ts
+++ b/javascript/app-framework/src/components/app/ResourcesPane/ResourcesPane.types.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import type { DataTableSchema } from '@datashaper/schema'
+import type { CodebookSchema, DataTableSchema } from '@datashaper/schema'
 import type { TableContainer } from '@datashaper/tables'
 import type { BaseFile } from '@datashaper/utilities'
 
@@ -66,6 +66,7 @@ export type AddTableHandler = (
 	file: BaseFile,
 	table: TableContainer,
 	schema: DataTableSchema,
+	codebook?: CodebookSchema,
 ) => void
 
 export interface FileDefinition {

--- a/javascript/app-framework/src/components/tables/ImportTable/ImportTable.styles.ts
+++ b/javascript/app-framework/src/components/tables/ImportTable/ImportTable.styles.ts
@@ -67,7 +67,9 @@ export const Footer = styled.div`
 	width: 100%;
 	display: flex;
 	justify-content: flex-end;
-	padding: 0 10px ${PADDING}px 0;
+	align-items: center;
+	gap: ${PADDING * 2}px;
+	padding: 0 ${PADDING}px ${PADDING}px 0;
 `
 
 export const textFieldStyles = {

--- a/javascript/app-framework/src/components/tables/ImportTable/ImportTable.types.ts
+++ b/javascript/app-framework/src/components/tables/ImportTable/ImportTable.types.ts
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import type { DataTableSchema } from '@datashaper/schema'
+import type { CodebookSchema, DataTableSchema } from '@datashaper/schema'
 import type { TableContainer } from '@datashaper/tables'
 import type { BaseFile } from '@datashaper/utilities'
 
@@ -15,4 +15,5 @@ export interface ImportTableProps {
 export type OpenTableHandler = (
 	table: TableContainer,
 	schema: DataTableSchema,
+	codebook?: CodebookSchema,
 ) => void

--- a/javascript/workflow/src/resources/DataTable.ts
+++ b/javascript/workflow/src/resources/DataTable.ts
@@ -48,7 +48,7 @@ export class DataTable extends Resource implements TableEmitter {
 
 	private refreshData = (): void => {
 		if (this._rawData != null) {
-			readTable(this._rawData, this.toSchema())
+			readTable(this._rawData, this.toSchema(), { autoType: false })
 				.then(t => this._output$.next({ table: t, id: this.name }))
 				.catch(err => {
 					log('error reading blob', err)

--- a/schema/fixtures/datapackages/covid-19/datapackage.json
+++ b/schema/fixtures/datapackages/covid-19/datapackage.json
@@ -14,6 +14,162 @@
 					"layout": "micro"
 				},
 				{
+					"$schema": "https://microsoft.github.io/datashaper/schema/codebook/v1.0.0.json",
+					"profile": "codebook",
+					"fields": [
+						{
+							"name": "ID",
+							"type": "number",
+							"nature": "discrete"
+						},
+						{
+							"name": "age",
+							"type": "string",
+							"nature": "nominal"
+						},
+						{
+							"name": "DateOfOnsetSymptoms",
+							"type": "date",
+							"nature": "nominal"
+						},
+						{
+							"name": "ChronicDiseaseQ",
+							"type": "number",
+							"nature": "binary"
+						},
+						{
+							"name": "gender_binary",
+							"type": "number",
+							"nature": "binary"
+						},
+						{
+							"name": "death_binary",
+							"type": "number",
+							"nature": "binary"
+						},
+						{
+							"name": "respiratory",
+							"type": "number",
+							"nature": "binary"
+						},
+						{
+							"name": "weakness/pain",
+							"type": "number",
+							"nature": "binary"
+						},
+						{
+							"name": "fever",
+							"type": "number",
+							"nature": "binary"
+						},
+						{
+							"name": "gastrointestinal",
+							"type": "number",
+							"nature": "binary"
+						},
+						{
+							"name": "other",
+							"type": "number",
+							"nature": "binary"
+						},
+						{
+							"name": "nausea",
+							"type": "number",
+							"nature": "binary"
+						},
+						{
+							"name": "cardiac",
+							"type": "number",
+							"nature": "binary"
+						},
+						{
+							"name": "high fever",
+							"type": "number",
+							"nature": "binary"
+						},
+						{
+							"name": "kidney",
+							"type": "number",
+							"nature": "binary"
+						},
+						{
+							"name": "asymptomatic",
+							"type": "number",
+							"nature": "binary"
+						},
+						{
+							"name": "diabetes",
+							"type": "number",
+							"nature": "binary"
+						},
+						{
+							"name": "neuro",
+							"type": "number",
+							"nature": "binary"
+						},
+						{
+							"name": "NA",
+							"type": "number",
+							"nature": "binary"
+						},
+						{
+							"name": "hypertension",
+							"type": "number",
+							"nature": "binary"
+						},
+						{
+							"name": "cancer",
+							"type": "number",
+							"nature": "binary"
+						},
+						{
+							"name": "ortho",
+							"type": "number",
+							"nature": "binary"
+						},
+						{
+							"name": "respiratory_CD",
+							"type": "number",
+							"nature": "binary"
+						},
+						{
+							"name": "cardiacs_cd",
+							"type": "number",
+							"nature": "binary"
+						},
+						{
+							"name": "kidney_CD",
+							"type": "number",
+							"nature": "binary"
+						},
+						{
+							"name": "blood",
+							"type": "number",
+							"nature": "binary"
+						},
+						{
+							"name": "prostate",
+							"type": "number",
+							"nature": "binary"
+						},
+						{
+							"name": "thyroid",
+							"type": "number",
+							"nature": "binary"
+						},
+						{
+							"name": "Latitude",
+							"type": "number",
+							"nature": "continuous"
+						},
+						{
+							"name": "Longitiude",
+							"type": "number",
+							"nature": "continuous"
+						}
+					]
+				},
+				{
 					"$schema": "https://microsoft.github.io/datashaper/schema/workflow/v2.json",
 					"profile": "workflow",
 					"steps": [
@@ -23,20 +179,6 @@
 								"operation": "row_number",
 								"to": "index"
 							}
-						},
-						{
-							"args": {
-								"columns": [
-									"index",
-									"age",
-									"ChronicDiseaseQ",
-									"gender_binary",
-									"death_binary",
-									"hypertension",
-									"diabetes"
-								]
-							},
-							"verb": "select"
 						},
 						{
 							"args": {
@@ -323,63 +465,63 @@
 						{
 							"args": {
 								"to": "age_group_1",
-								"value": "1"
+								"value": 1
 							},
 							"verb": "fill"
 						},
 						{
 							"args": {
 								"to": "age_group_2",
-								"value": "2"
+								"value": 2
 							},
 							"verb": "fill"
 						},
 						{
 							"args": {
 								"to": "age_group_3",
-								"value": "3"
+								"value": 3
 							},
 							"verb": "fill"
 						},
 						{
 							"args": {
 								"to": "age_group_4",
-								"value": "4"
+								"value": 4
 							},
 							"verb": "fill"
 						},
 						{
 							"args": {
 								"to": "age_group_5",
-								"value": "5"
+								"value": 5
 							},
 							"verb": "fill"
 						},
 						{
 							"args": {
 								"to": "age_group_6",
-								"value": "6"
+								"value": 6
 							},
 							"verb": "fill"
 						},
 						{
 							"args": {
 								"to": "age_group_7",
-								"value": "7"
+								"value": 7
 							},
 							"verb": "fill"
 						},
 						{
 							"args": {
 								"to": "age_group_8",
-								"value": "8"
+								"value": 8
 							},
 							"verb": "fill"
 						},
 						{
 							"args": {
 								"to": "age_group_9",
-								"value": "9"
+								"value": 9
 							},
 							"verb": "fill"
 						},
@@ -547,13 +689,6 @@
 						},
 						{
 							"args": {
-								"columns": ["Combined"],
-								"type": "float"
-							},
-							"verb": "convert"
-						},
-						{
-							"args": {
 								"column": "Combined",
 								"to": "diabetes_hypertension",
 								"criteria": [
@@ -568,22 +703,8 @@
 						},
 						{
 							"args": {
-								"columns": [
-									"index",
-									"age",
-									"chronic_disease",
-									"gender",
-									"death",
-									"age_group",
-									"diabetes_hypertension"
-								]
-							},
-							"verb": "select"
-						},
-						{
-							"args": {
 								"to": "subject_inclusion",
-								"value": "1"
+								"value": 1
 							},
 							"verb": "fill"
 						},

--- a/schema/fixtures/datapackages/covid-19/expected.json
+++ b/schema/fixtures/datapackages/covid-19/expected.json
@@ -2,7 +2,7 @@
 	"tables": [
 		{
 			"name": "covid19_small_data",
-			"workflowLength": 55
+			"workflowLength": 52
 		}
 	]
 }


### PR DESCRIPTION
- turns off autotyping by default, so imported tables remain string content
- adds checkbox on import to detect types. If this is checked, a codebook as generated and typing information is therefore stored (this is checked on by default).
- fixes datapackage tests that implicitly depended on default autotyping