### PR TITLE
Add Import Progress Feedback

### DIFF
--- a/.yarn/versions/f080a936.yml
+++ b/.yarn/versions/f080a936.yml
@@ -1,0 +1,9 @@
+releases:
+  "@datashaper/app-framework": patch
+  "@datashaper/react": patch
+  "@datashaper/tables": major
+  "@datashaper/workflow": patch
+
+declined:
+  - "@datashaper/stories"
+  - "@datashaper/webapp"

--- a/javascript/app-framework/src/components/DataTableConfig/DataTableConfig.hooks.ts
+++ b/javascript/app-framework/src/components/DataTableConfig/DataTableConfig.hooks.ts
@@ -4,7 +4,7 @@
  */
 import { DataFormat, DataOrientation } from '@datashaper/schema'
 import type { DataTable } from '@datashaper/workflow'
-import type { IChoiceGroupOption } from '@fluentui/react'
+import type { IDropdownOption } from '@fluentui/react'
 import { useObservableState } from 'observable-hooks'
 import { useCallback } from 'react'
 
@@ -12,14 +12,14 @@ export function useChangeHandlers(resource: DataTable): {
 	format: DataFormat
 	onChangeFormat: (
 		evt?: React.FormEvent<HTMLElement | HTMLInputElement>,
-		option?: IChoiceGroupOption,
+		option?: IDropdownOption,
 	) => void
 } {
 	const format = useObservableState(resource.format$, resource.format)
 	const onChangeFormat = useCallback(
 		(
 			_e?: React.FormEvent<HTMLElement | HTMLInputElement>,
-			option?: IChoiceGroupOption,
+			option?: IDropdownOption,
 		) => {
 			resource.format = option?.key as DataFormat
 			if (option?.key === DataFormat.CSV) {

--- a/javascript/app-framework/src/components/DataTableConfig/DataTableConfig.styles.ts
+++ b/javascript/app-framework/src/components/DataTableConfig/DataTableConfig.styles.ts
@@ -15,7 +15,6 @@ export const FormatContainer = styled.div`
 	width: 100%;
 	display: flex;
 	flex-direction: row;
-	justify-content: center;
 `
 
 export const ParserContainer = styled.div`
@@ -28,4 +27,3 @@ export const ShapeContainer = styled.div`
 	flex-direction: column;
 	gap: 12px;
 `
-export const buttonChoiceGroupStyles = { alignSelf: 'flex-start' }

--- a/javascript/app-framework/src/components/DataTableConfig/DataTableConfig.tsx
+++ b/javascript/app-framework/src/components/DataTableConfig/DataTableConfig.tsx
@@ -4,13 +4,12 @@
  */
 import { DataFormat } from '@datashaper/schema'
 import type { DataTable } from '@datashaper/workflow'
-import { ButtonChoiceGroup } from '@essex/components'
+import { Dropdown } from '@fluentui/react'
 import { memo } from 'react'
 import { Case, Switch } from 'react-if'
 
 import { useChangeHandlers } from './DataTableConfig.hooks.js'
 import {
-	buttonChoiceGroupStyles,
 	Container,
 	FormatContainer,
 	ParserContainer,
@@ -30,8 +29,8 @@ export const DataTableConfig: React.FC<DataTableSchemaComponentProps> = memo(
 		return (
 			<Container>
 				<FormatContainer>
-					<ButtonChoiceGroup
-						style={buttonChoiceGroupStyles}
+					<Dropdown
+						label='Data Format'
 						options={DATA_FORMAT_OPTIONS}
 						selectedKey={format}
 						onChange={onChangeFormat}

--- a/javascript/app-framework/src/components/tables/ImportTable/ImportTable.hooks.ts
+++ b/javascript/app-framework/src/components/tables/ImportTable/ImportTable.hooks.ts
@@ -2,7 +2,11 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project.
  */
-import { DataFormat, DataOrientation, type CodebookSchema } from '@datashaper/schema'
+import {
+	DataFormat,
+	DataOrientation,
+	type CodebookSchema,
+} from '@datashaper/schema'
 import { type TableMetadata, introspect, readTable } from '@datashaper/tables'
 import type { BaseFile } from '@datashaper/utilities'
 import { extension, guessDelimiter } from '@datashaper/utilities'
@@ -136,7 +140,7 @@ export function useCodebook(
 				autoType,
 				format,
 				onInferring: setColumnBeingInferred,
-				onProgress: setProgress
+				onProgress: setProgress,
 			})
 				.then(setCodebook)
 				.catch((err) => console.error(err))

--- a/javascript/app-framework/src/components/tables/ImportTable/ImportTable.tsx
+++ b/javascript/app-framework/src/components/tables/ImportTable/ImportTable.tsx
@@ -4,10 +4,11 @@
  */
 import { StatsColumnType } from '@datashaper/react'
 import type { TableContainer, TableMetadata } from '@datashaper/tables'
-import { generateCodebook } from '@datashaper/tables'
 import { removeExtension } from '@datashaper/utilities'
 import { ReadOnlyTextField } from '@essex/components'
 import {
+	Spinner,
+	ProgressIndicator,
 	Checkbox,
 	IconButton,
 	Label,
@@ -21,6 +22,7 @@ import { memo, useCallback, useState } from 'react'
 import { DataTableConfig } from '../../DataTableConfig/DataTableConfig.js'
 import { RawTable } from '../RawTable/RawTable.js'
 import {
+	useCodebook,
 	useDraftSchema,
 	useFileAttributes,
 	usePreview,
@@ -50,7 +52,7 @@ export const ImportTable: React.FC<ImportTableProps> = memo(
 		const isDataFormatTyped = format === DataFormat.ARROW
 
 		const [name, setName] = useState<string>(removeExtension(file.name ?? ''))
-		const [autoType, setAutoType] = useState<boolean>(!isDataFormatTyped)
+		const [autoType, setAutoType] = useState<boolean>(true)
 
 		const { table, metadata, previewError, onLoadPreview } = usePreview(
 			file,
@@ -58,6 +60,12 @@ export const ImportTable: React.FC<ImportTableProps> = memo(
 		)
 
 		const draftSchema = useDraftSchema(delimiter, format, onLoadPreview)
+		const {
+			codebook,
+			isLoading: isCodebookLoading,
+			columnBeingInferred,
+			progress: codebookProgress,
+		} = useCodebook(table, autoType, format)
 
 		const onClickImport = useCallback(() => {
 			if (table) {
@@ -65,10 +73,9 @@ export const ImportTable: React.FC<ImportTableProps> = memo(
 				const tableContainer = { id, table } as TableContainer
 				// TODO: this is a bit inefficient, because a codebook is generated transitively in the readTable method when autoType is true
 				// we should separate those two functions. if a table is typed, generating the codebook can be much quicker.
-				const codebook = autoType ? generateCodebook(table) : undefined
 				onOpenTable(tableContainer, draftSchema.toSchema(), codebook)
 			}
-		}, [onOpenTable, table, name, extension, draftSchema, autoType])
+		}, [onOpenTable, table, name, extension, draftSchema, codebook])
 
 		return (
 			<Modal styles={modalStyles} isOpen={true} onDismiss={onCancel} isBlocking>
@@ -76,13 +83,13 @@ export const ImportTable: React.FC<ImportTableProps> = memo(
 				<ModalBody>
 					<Sidebar>
 						<TextField
-							label='Table name'
+							label="Table name"
 							onChange={(_, value) => setName(value ?? '')}
 							description={file.path ?? ''}
 							value={name}
-							name='fileName'
-							title='Table name'
-							autoComplete='off'
+							name="fileName"
+							title="Table name"
+							autoComplete="off"
 						/>
 						<DataTableConfig resource={draftSchema} />
 					</Sidebar>
@@ -97,10 +104,31 @@ export const ImportTable: React.FC<ImportTableProps> = memo(
 								/>
 							</>
 						)}
-						<Label>Final table</Label>
-						<PreviewContent>
-							<Preview error={previewError} table={table} metadata={metadata} />
-						</PreviewContent>
+						{isCodebookLoading ? (
+							<>
+								<Spinner />
+								<Label>
+									{columnBeingInferred == null
+										? ''
+										: `Inferring type of ${columnBeingInferred}`}
+								</Label>
+
+								<ProgressIndicator
+									percentComplete={codebookProgress / (table?.numCols() || 1)}
+								/>
+							</>
+						) : (
+							<>
+								<Label>Final table</Label>
+								<PreviewContent>
+									<Preview
+										error={previewError}
+										table={table}
+										metadata={metadata}
+									/>
+								</PreviewContent>
+							</>
+						)}
 					</MainContent>
 				</ModalBody>
 				<ModalFooter
@@ -122,7 +150,7 @@ const ModalHeader: React.FC<{ onHideModal: () => void }> = memo(
 				<HeaderTitle>Open table</HeaderTitle>
 				<IconButton
 					iconProps={icons.cancel}
-					ariaLabel='Close popup modal'
+					ariaLabel="Close popup modal"
 					onClick={onHideModal}
 				/>
 			</Header>
@@ -137,7 +165,6 @@ const ModalFooter: React.FC<{
 	onAutoTypeChange: (checked: boolean) => void
 	onClick: () => void
 }> = memo(function ModalFooter({
-	autotypeDisabled,
 	disabled,
 	autoType,
 	onAutoTypeChange,
@@ -145,16 +172,14 @@ const ModalFooter: React.FC<{
 }) {
 	return (
 		<Footer>
-			{!autotypeDisabled && (
-				<Checkbox
-					label={'Discover data types'}
-					checked={autoType}
-					onChange={(_: any, checked?: boolean) =>
-						onAutoTypeChange(checked ?? false)
-					}
-				/>
-			)}
-			<PrimaryButton disabled={disabled} text='OK' onClick={onClick} />
+			<Checkbox
+				label={'Discover data types'}
+				checked={autoType}
+				onChange={(_: any, checked?: boolean) =>
+					onAutoTypeChange(checked ?? false)
+				}
+			/>
+			<PrimaryButton disabled={disabled} text="OK" onClick={onClick} />
 		</Footer>
 	)
 })

--- a/javascript/app-framework/src/components/tables/ImportTable/ImportTable.tsx
+++ b/javascript/app-framework/src/components/tables/ImportTable/ImportTable.tsx
@@ -83,13 +83,13 @@ export const ImportTable: React.FC<ImportTableProps> = memo(
 				<ModalBody>
 					<Sidebar>
 						<TextField
-							label="Table name"
+							label='Table name'
 							onChange={(_, value) => setName(value ?? '')}
 							description={file.path ?? ''}
 							value={name}
-							name="fileName"
-							title="Table name"
-							autoComplete="off"
+							name='fileName'
+							title='Table name'
+							autoComplete='off'
 						/>
 						<DataTableConfig resource={draftSchema} />
 					</Sidebar>
@@ -150,7 +150,7 @@ const ModalHeader: React.FC<{ onHideModal: () => void }> = memo(
 				<HeaderTitle>Open table</HeaderTitle>
 				<IconButton
 					iconProps={icons.cancel}
-					ariaLabel="Close popup modal"
+					ariaLabel='Close popup modal'
 					onClick={onHideModal}
 				/>
 			</Header>
@@ -179,7 +179,7 @@ const ModalFooter: React.FC<{
 					onAutoTypeChange(checked ?? false)
 				}
 			/>
-			<PrimaryButton disabled={disabled} text="OK" onClick={onClick} />
+			<PrimaryButton disabled={disabled} text='OK' onClick={onClick} />
 		</Footer>
 	)
 })

--- a/javascript/app-framework/src/profiles/TableBundleAppProfile.ts
+++ b/javascript/app-framework/src/profiles/TableBundleAppProfile.ts
@@ -111,12 +111,15 @@ export class TableBundleAppProfile
 				text: 'Add Codebook',
 				iconProps: { iconName: this.codebookProfile.iconName },
 				onClick: () => {
-					const table = resource.input?.output?.table
-					this.codebookProfile
-						.createInstance?.(table && generateCodebook(table))
-						.then((codebook) => {
+					const execute = async () => {
+						const table = resource.input?.output?.table
+						const codebook = table && (await generateCodebook(table))
+
+						this.codebookProfile.createInstance?.(codebook).then((codebook) => {
 							resource.sources = [...resource.sources, codebook]
 						})
+					}
+					void execute()
 				},
 			})
 		}

--- a/javascript/react/src/components/verbs/forms/EncodeDecodeForm/EncodeDecodeForm.hooks.tsx
+++ b/javascript/react/src/components/verbs/forms/EncodeDecodeForm/EncodeDecodeForm.hooks.tsx
@@ -5,12 +5,16 @@
 import type { CodebookSchema } from '@datashaper/schema'
 import { generateCodebook } from '@datashaper/tables'
 import type ColumnTable from 'arquero/dist/types/table/column-table.js'
-import { useMemo } from 'react'
+import { useEffect, useState } from 'react'
 
 export function useCodebookContent(
 	table?: ColumnTable,
 ): CodebookSchema | undefined {
-	return useMemo(() => {
-		return table && generateCodebook(table)
+	const [codebook, setCodebook] = useState<CodebookSchema | undefined>()
+	useEffect(() => {
+		if (table) {
+			generateCodebook(table).then(setCodebook)
+		}
 	}, [table])
+	return codebook
 }

--- a/javascript/tables/docs/markdown/tables.formatnumberstr.md
+++ b/javascript/tables/docs/markdown/tables.formatnumberstr.md
@@ -19,8 +19,8 @@ export declare function formatNumberStr(value: string | number, options?: {
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  value | string \| number |  |
-|  options | { decimal?: string; thousands?: string; } | <i>(Optional)</i> |
+|  value | string \| number | the value to format |
+|  options | { decimal?: string; thousands?: string; } | <i>(Optional)</i> formatting options |
 
 <b>Returns:</b>
 

--- a/javascript/tables/docs/markdown/tables.fromcsv.md
+++ b/javascript/tables/docs/markdown/tables.fromcsv.md
@@ -9,7 +9,7 @@ Drop-in replacement for arquero fromCSV, using our internal parsing with auto-ty
 <b>Signature:</b>
 
 ```typescript
-export declare function fromCSV(text: string, options?: CSVParseOptions): ColumnTable;
+export declare function fromCSV(text: string, options?: CSVParseOptions): Promise<ColumnTable>;
 ```
 
 ## Parameters
@@ -21,5 +21,5 @@ export declare function fromCSV(text: string, options?: CSVParseOptions): Column
 
 <b>Returns:</b>
 
-ColumnTable
+Promise&lt;ColumnTable&gt;
 

--- a/javascript/tables/docs/markdown/tables.generatecodebook.md
+++ b/javascript/tables/docs/markdown/tables.generatecodebook.md
@@ -8,9 +8,12 @@
 
 ```typescript
 export declare function generateCodebook(table: ColumnTable, options?: {
+    format?: DataFormat;
     autoType?: boolean;
     autoMax?: number;
-}): CodebookSchema;
+    onInferring?: (column: string) => void;
+    onProgress?: (numComplete: number) => void;
+}): Promise<CodebookSchema>;
 ```
 
 ## Parameters
@@ -18,9 +21,9 @@ export declare function generateCodebook(table: ColumnTable, options?: {
 |  Parameter | Type | Description |
 |  --- | --- | --- |
 |  table | ColumnTable |  |
-|  options | { autoType?: boolean; autoMax?: number; } | <i>(Optional)</i> |
+|  options | { format?: DataFormat; autoType?: boolean; autoMax?: number; onInferring?: (column: string) =&gt; void; onProgress?: (numComplete: number) =&gt; void; } | <i>(Optional)</i> |
 
 <b>Returns:</b>
 
-CodebookSchema
+Promise&lt;CodebookSchema&gt;
 

--- a/javascript/tables/docs/markdown/tables.validatecolumn.md
+++ b/javascript/tables/docs/markdown/tables.validatecolumn.md
@@ -16,7 +16,7 @@ export declare function validateColumn(table: ColumnTable, field: Field, include
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  table | ColumnTable |  |
+|  table | ColumnTable | the table to validate |
 |  field | Field |  |
 |  includeIndexes | boolean | indicate whether to include the indexes of the row instances that failed validation |
 

--- a/javascript/tables/docs/markdown/tables.validatetable.md
+++ b/javascript/tables/docs/markdown/tables.validatetable.md
@@ -16,8 +16,8 @@ export declare function validateTable(table: ColumnTable, codebook: CodebookSche
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  table | ColumnTable |  |
-|  codebook | CodebookSchema |  |
+|  table | ColumnTable | the table to validate |
+|  codebook | CodebookSchema | the codebook to use |
 |  includeIndexes | boolean | <i>(Optional)</i> indicate whether to include the indexes of the rows that failed validation for each field |
 
 <b>Returns:</b>

--- a/javascript/tables/docs/report/tables.api.json
+++ b/javascript/tables/docs/report/tables.api.json
@@ -1124,7 +1124,7 @@
         {
           "kind": "Function",
           "canonicalReference": "@datashaper/tables!formatNumberStr:function(1)",
-          "docComment": "/**\n * Formats a string using specified numeric parser options, so that it is ready for standard numeric parsing. (i.e., default js impl is to consider '.' a decimal). If the string has invalid construction to be a number, an empty string will be returned, which will be parsed as NaN. We do this because parseInt does not recognize the thousands separator, but if we remove them all even in invalid cases (e.g., '1,00'), invalid numbers could be parsed downstream as valid. The same occurs with decimal separators: parseFloat will ignore anything after the first.\n *\n * @param value - \n *\n * @param options - \n *\n * @returns \n */\n",
+          "docComment": "/**\n * Formats a string using specified numeric parser options, so that it is ready for standard numeric parsing. (i.e., default js impl is to consider '.' a decimal). If the string has invalid construction to be a number, an empty string will be returned, which will be parsed as NaN. We do this because parseInt does not recognize the thousands separator, but if we remove them all even in invalid cases (e.g., '1,00'), invalid numbers could be parsed downstream as valid. The same occurs with decimal separators: parseFloat will ignore anything after the first.\n *\n * @param value - the value to format\n *\n * @param options - formatting options\n *\n * @returns \n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -1209,8 +1209,21 @@
             },
             {
               "kind": "Reference",
+              "text": "Promise",
+              "canonicalReference": "!Promise:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
               "text": "ColumnTable",
               "canonicalReference": "arquero!default:class"
+            },
+            {
+              "kind": "Content",
+              "text": ">"
             },
             {
               "kind": "Content",
@@ -1219,7 +1232,7 @@
           ],
           "returnTypeTokenRange": {
             "startIndex": 5,
-            "endIndex": 6
+            "endIndex": 9
           },
           "releaseTag": "Public",
           "overloadIndex": 1,
@@ -1263,11 +1276,29 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    autoType?: boolean;\n    autoMax?: number;\n}"
+              "text": "{\n    format?: "
+            },
+            {
+              "kind": "Reference",
+              "text": "DataFormat",
+              "canonicalReference": "@datashaper/schema!DataFormat:enum"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n    autoType?: boolean;\n    autoMax?: number;\n    onInferring?: (column: string) => void;\n    onProgress?: (numComplete: number) => void;\n}"
             },
             {
               "kind": "Content",
               "text": "): "
+            },
+            {
+              "kind": "Reference",
+              "text": "Promise",
+              "canonicalReference": "!Promise:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
             },
             {
               "kind": "Reference",
@@ -1276,12 +1307,16 @@
             },
             {
               "kind": "Content",
+              "text": ">"
+            },
+            {
+              "kind": "Content",
               "text": ";"
             }
           ],
           "returnTypeTokenRange": {
-            "startIndex": 5,
-            "endIndex": 6
+            "startIndex": 7,
+            "endIndex": 11
           },
           "releaseTag": "Public",
           "overloadIndex": 1,
@@ -1298,7 +1333,7 @@
               "parameterName": "options",
               "parameterTypeTokenRange": {
                 "startIndex": 3,
-                "endIndex": 4
+                "endIndex": 6
               },
               "isOptional": true
             }
@@ -3819,7 +3854,7 @@
         {
           "kind": "Function",
           "canonicalReference": "@datashaper/tables!validateColumn:function(1)",
-          "docComment": "/**\n * Validates a column against a Field definition's constraints.\n *\n * @param table - \n *\n * @param name - \n *\n * @param dataType - \n *\n * @param constraints - \n *\n * @param includeIndexes - indicate whether to include the indexes of the row instances that failed validation\n *\n * @returns \n */\n",
+          "docComment": "/**\n * Validates a column against a Field definition's constraints.\n *\n * @param table - the table to validate\n *\n * @param name - the name of the column\n *\n * @param dataType - the type of the column\n *\n * @param constraints - the field constraints to validate against\n *\n * @param includeIndexes - indicate whether to include the indexes of the row instances that failed validation\n *\n * @returns \n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -3898,7 +3933,7 @@
         {
           "kind": "Function",
           "canonicalReference": "@datashaper/tables!validateTable:function(1)",
-          "docComment": "/**\n * Validates an entire table against a codebook's Field constraints.\n *\n * @param table - \n *\n * @param codebook - \n *\n * @param includeIndexes - indicate whether to include the indexes of the rows that failed validation for each field\n *\n * @returns \n */\n",
+          "docComment": "/**\n * Validates an entire table against a codebook's Field constraints.\n *\n * @param table - the table to validate\n *\n * @param codebook - the codebook to use\n *\n * @param includeIndexes - indicate whether to include the indexes of the rows that failed validation for each field\n *\n * @returns \n */\n",
           "excerptTokens": [
             {
               "kind": "Content",

--- a/javascript/tables/docs/report/tables.api.md
+++ b/javascript/tables/docs/report/tables.api.md
@@ -9,6 +9,7 @@ import { CodebookStrategy } from '@datashaper/schema';
 import type ColumnTable from 'arquero/dist/types/table/column-table';
 import type { default as ColumnTable_2 } from 'arquero/dist/types/table/column-table.js';
 import type { CSVParseOptions } from 'arquero/dist/types/format/from-csv.js';
+import { DataFormat } from '@datashaper/schema';
 import type { DataTableSchema } from '@datashaper/schema';
 import { DataType } from '@datashaper/schema';
 import type { Field } from '@datashaper/schema';
@@ -98,15 +99,18 @@ export function formatNumberStr(value: string | number, options?: {
 // Warning: (ae-missing-release-tag) "fromCSV" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public
-export function fromCSV(text: string, options?: CSVParseOptions): ColumnTable_2;
+export function fromCSV(text: string, options?: CSVParseOptions): Promise<ColumnTable_2>;
 
 // Warning: (ae-missing-release-tag) "generateCodebook" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
 // @public (undocumented)
 export function generateCodebook(table: ColumnTable, options?: {
+    format?: DataFormat;
     autoType?: boolean;
     autoMax?: number;
-}): CodebookSchema;
+    onInferring?: (column: string) => void;
+    onProgress?: (numComplete: number) => void;
+}): Promise<CodebookSchema>;
 
 // Warning: (ae-missing-release-tag) "getDate" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //

--- a/javascript/tables/src/__tests__/applyCodebook.spec.ts
+++ b/javascript/tables/src/__tests__/applyCodebook.spec.ts
@@ -29,112 +29,118 @@ describe('applyCodebook', () => {
 	const arrays = fromCSV(csv3, { autoType: false })
 
 	describe('CodebookMapping.DataTypeOnly', () => {
-		const codebook = generateCodebook(simple)
+		async function result() {
+			const table = await simple
+			const codebook = await generateCodebook(table)
+			return applyCodebook(table, codebook, CodebookStrategy.DataTypeOnly)
+		}
 
-		const result = applyCodebook(
-			simple,
-			codebook,
-			CodebookStrategy.DataTypeOnly,
-		)
-
-		it('should return a column table', () => {
-			expect(result.numRows()).toBe(10)
-			expect(result.numCols()).toBe(8)
+		it('should return a column table', async () => {
+			const res = await result()
+			expect(res.numRows()).toBe(10)
+			expect(res.numCols()).toBe(8)
 		})
-		it('column types are correctly parsed', () => {
-			expect(typeof result.get('index', 0)).toBe('number')
-			expect(typeof result.get('float', 0)).toBe('number')
-			expect(typeof result.get('boolean', 0)).toBe('boolean')
+		it('column types are correctly parsed', async () => {
+			const res = await result()
+			expect(typeof res.get('index', 0)).toBe('number')
+			expect(typeof res.get('float', 0)).toBe('number')
+			expect(typeof res.get('boolean', 0)).toBe('boolean')
 		})
 	})
 
 	describe('CodebookMapping.DataTypeOnly (arrays)', () => {
-		const codebook = generateCodebook(arrays)
+		async function result() {
+			const table = await arrays
+			const codebook = await generateCodebook(table)
+			return applyCodebook(table, codebook, CodebookStrategy.DataTypeOnly)
+		}
 
-		const result = applyCodebook(
-			arrays,
-			codebook,
-			CodebookStrategy.DataTypeOnly,
-		)
-
-		it('should return a column table', () => {
-			expect(result.numRows()).toBe(5)
-			expect(result.numCols()).toBe(3)
+		it('should return a column table', async () => {
+			const res = await result()
+			expect(res.numRows()).toBe(5)
+			expect(res.numCols()).toBe(3)
 		})
-		it('column array subtypes are correctly parsed', () => {
-			expect(typeof result.get('id', 0)).toBe('number')
-			expect(result.get('numbers', 0)).toEqual([1, 2, 3, 4])
-			expect(result.get('booleans', 0)).toEqual([true, true, false])
+		it('column array subtypes are correctly parsed', async () => {
+			const res = await result()
+			expect(typeof res.get('id', 0)).toBe('number')
+			expect(res.get('numbers', 0)).toEqual([1, 2, 3, 4])
+			expect(res.get('booleans', 0)).toEqual([true, true, false])
 		})
 	})
 
 	describe('CodebookMapping.DataTypeAndMapping', () => {
-		const codebook = generateCodebook(mapping)
+		async function result() {
+			const table = await mapping
+			const codebook = await generateCodebook(table)
 
-		const element = codebook.fields.find(
-			(element) => element.name === 'diagnosis',
-		)
+			const element = codebook.fields.find(
+				(element) => element.name === 'diagnosis',
+			)
 
-		const mappingElements: Record<number, string> = {
-			0: 'heart disease',
-			1: 'diabetes type I',
-			2: 'diabetes type II',
-			3: 'diabetes type III',
+			const mappingElements: Record<number, string> = {
+				0: 'heart disease',
+				1: 'diabetes type I',
+				2: 'diabetes type II',
+				3: 'diabetes type III',
+			}
+
+			if (element) {
+				element.mapping = mappingElements
+			}
+
+			const element2 = codebook.fields.find(
+				(element) => element.name === 'test',
+			)
+			const mappingElements2: Record<number, string> = {
+				0: 'Test1',
+				1: 'Test2',
+				2: 'Test3',
+				3: 'Test4',
+			}
+
+			if (element2) {
+				element2.mapping = mappingElements2
+			}
+
+			return applyCodebook(table, codebook, CodebookStrategy.DataTypeAndMapping)
 		}
 
-		element.mapping = mappingElements
-
-		const element2 = codebook.fields.find((element) => element.name === 'test')
-		const mappingElements2: Record<number, string> = {
-			0: 'Test1',
-			1: 'Test2',
-			2: 'Test3',
-			3: 'Test4',
-		}
-
-		element2.mapping = mappingElements2
-
-		const result = applyCodebook(
-			mapping,
-			codebook,
-			CodebookStrategy.DataTypeAndMapping,
-		)
-
-		it('should return a column table with mapping values', () => {
-			expect(result.numRows()).toBe(7)
-			expect(result.numCols()).toBe(3)
-			expect(result.get('diagnosis', 0)).toBe('heart disease')
-			expect(result.get('diagnosis', 1)).toBe('heart disease')
-			expect(result.get('diagnosis', 2)).toBe('diabetes type I')
-			expect(result.get('diagnosis', 3)).toBe('diabetes type III')
-			expect(result.get('diagnosis', 4)).toBe('diabetes type I')
-			expect(result.get('diagnosis', 5)).toBe('diabetes type II')
-			expect(result.get('diagnosis', 6)).toBe('diabetes type III')
-			expect(result.get('test', 0)).toBe('Test1')
-			expect(result.get('test', 1)).toBe('Test1')
-			expect(result.get('test', 2)).toBe('Test2')
-			expect(result.get('test', 3)).toBe('Test4')
-			expect(result.get('test', 4)).toBe('Test2')
-			expect(result.get('test', 5)).toBe('Test3')
-			expect(result.get('test', 6)).toBe('Test4')
+		it('should return a column table with mapping values', async () => {
+			const res = await result()
+			expect(res.numRows()).toBe(7)
+			expect(res.numCols()).toBe(3)
+			expect(res.get('diagnosis', 0)).toBe('heart disease')
+			expect(res.get('diagnosis', 1)).toBe('heart disease')
+			expect(res.get('diagnosis', 2)).toBe('diabetes type I')
+			expect(res.get('diagnosis', 3)).toBe('diabetes type III')
+			expect(res.get('diagnosis', 4)).toBe('diabetes type I')
+			expect(res.get('diagnosis', 5)).toBe('diabetes type II')
+			expect(res.get('diagnosis', 6)).toBe('diabetes type III')
+			expect(res.get('test', 0)).toBe('Test1')
+			expect(res.get('test', 1)).toBe('Test1')
+			expect(res.get('test', 2)).toBe('Test2')
+			expect(res.get('test', 3)).toBe('Test4')
+			expect(res.get('test', 4)).toBe('Test2')
+			expect(res.get('test', 5)).toBe('Test3')
+			expect(res.get('test', 6)).toBe('Test4')
 		})
 	})
 
 	describe('ignore fields marked `exclude`', () => {
-		const codebook = generateCodebook(simple)
-		codebook.fields = codebook.fields
-			.slice(0, 3)
-			.map((f) => ({ ...f, exclude: true }))
+		async function result() {
+			const table = await simple
+			const codebook = await generateCodebook(table)
+			codebook.fields = codebook.fields
+				.slice(0, 3)
+				.map((f) => ({ ...f, exclude: true }))
 
-		const result = applyCodebook(
-			simple,
-			codebook,
-			CodebookStrategy.DataTypeOnly,
-		)
+			return applyCodebook(table, codebook, CodebookStrategy.DataTypeOnly)
+		}
 
-		it('should return a column table', () => {
-			expect(result.numRows()).toBe(10)
-			expect(result.numCols()).toBe(5)
+		it('should return a column table', async () => {
+			const res = await result()
+			expect(res.numRows()).toBe(10)
+			expect(res.numCols()).toBe(5)
 		})
 	})
 })

--- a/javascript/tables/src/__tests__/generateCodebook.spec.ts
+++ b/javascript/tables/src/__tests__/generateCodebook.spec.ts
@@ -119,7 +119,7 @@ describe('generateCodebook', () => {
 			// infers types from the string values, using the pandas-compatible type hints
 			const parsed = await fromCSV(csv, { autoType: false })
 			const codebook = await generateCodebook(parsed)
-			
+
 			expect(codebook.fields).toHaveLength(3)
 			expect(codebook.fields[0]?.name).toBe('id')
 			expect(codebook.fields[0]?.type).toBe(DataType.Number)

--- a/javascript/tables/src/__tests__/generateCodebook.spec.ts
+++ b/javascript/tables/src/__tests__/generateCodebook.spec.ts
@@ -18,11 +18,11 @@ describe('generateCodebook', () => {
 
 		// we are not autotyping here to confirm that our codebook generation correctly
 		// infers types from the string values, using the pandas-compatible type hints
-		const parsed = fromCSV(csv, { autoType: false })
 
-		const codebook = generateCodebook(parsed)
+		it('should return a codebook object', async () => {
+			const parsed = await fromCSV(csv, { autoType: false })
+			const codebook = await generateCodebook(parsed)
 
-		it('should return a codebook object', () => {
 			expect(codebook.fields).toHaveLength(8)
 			expect(codebook.fields[0]?.name).toBe('index')
 			expect(codebook.fields[0]?.type).toBe(DataType.Number)
@@ -65,11 +65,9 @@ describe('generateCodebook', () => {
 				flag: 'r',
 			})
 
-			const parsed = fromCSV(csv, { autoType: false })
-
-			const codebook = generateCodebook(parsed)
-
-			it('should return a codebook object', () => {
+			it('should return a codebook object', async () => {
+				const parsed = await fromCSV(csv, { autoType: false })
+				const codebook = await generateCodebook(parsed)
 				expect(codebook.fields).toHaveLength(9)
 				expect(codebook.fields[0]?.name).toBe('Symbol')
 				expect(codebook.fields[0]?.type).toBe(DataType.String)
@@ -116,13 +114,12 @@ describe('generateCodebook', () => {
 			flag: 'r',
 		})
 
-		// we are not autotyping here to confirm that our codebook generation correctly
-		// infers types from the string values, using the pandas-compatible type hints
-		const parsed = fromCSV(csv, { autoType: false })
-
-		const codebook = generateCodebook(parsed)
-
-		it('should discover array subtypes', () => {
+		it('should discover array subtypes', async () => {
+			// we are not autotyping here to confirm that our codebook generation correctly
+			// infers types from the string values, using the pandas-compatible type hints
+			const parsed = await fromCSV(csv, { autoType: false })
+			const codebook = await generateCodebook(parsed)
+			
 			expect(codebook.fields).toHaveLength(3)
 			expect(codebook.fields[0]?.name).toBe('id')
 			expect(codebook.fields[0]?.type).toBe(DataType.Number)

--- a/javascript/tables/src/__tests__/inferColumnNature.spec.ts
+++ b/javascript/tables/src/__tests__/inferColumnNature.spec.ts
@@ -10,16 +10,13 @@ import { inferColumnNature } from '../inferColumnNature.js'
 
 describe('Infer column nature tests', () => {
 	describe('discrete', () => {
-		const csv = fs.readFileSync('./src/__tests__/data/stocks.csv', {
-			encoding: 'utf8',
-			flag: 'r',
-		})
-
-		const parsed = fromCSV(csv)
-
-		const nature = inferColumnNature(parsed, 'Volume')
-
-		it('should return true', () => {
+		it('should return true', async () => {
+			const csv = fs.readFileSync('./src/__tests__/data/stocks.csv', {
+				encoding: 'utf8',
+				flag: 'r',
+			})
+			const parsed = await fromCSV(csv)
+			const nature = inferColumnNature(parsed, 'Volume')
 			expect(nature).toBe(VariableNature.Discrete)
 		})
 	})
@@ -30,11 +27,9 @@ describe('Infer column nature tests', () => {
 			flag: 'r',
 		})
 
-		const parsed = fromCSV(csv)
-
-		const nature = inferColumnNature(parsed, 'index', 11)
-
-		it('should return true', () => {
+		it('should return true', async () => {
+			const parsed = await fromCSV(csv)
+			const nature = inferColumnNature(parsed, 'index', 11)
 			expect(nature).toBe(VariableNature.Ordinal)
 		})
 	})
@@ -45,11 +40,9 @@ describe('Infer column nature tests', () => {
 			flag: 'r',
 		})
 
-		const parsed = fromCSV(csv)
-
-		const nature = inferColumnNature(parsed, 'Symbol')
-
-		it('should return true', () => {
+		it('should return true', async () => {
+			const parsed = await fromCSV(csv)
+			const nature = inferColumnNature(parsed, 'Symbol')
 			expect(nature).toBe(VariableNature.Nominal)
 		})
 	})
@@ -60,11 +53,9 @@ describe('Infer column nature tests', () => {
 			flag: 'r',
 		})
 
-		const parsed = fromCSV(csv)
-
-		const nature = inferColumnNature(parsed, 'US')
-
-		it('should return true', () => {
+		it('should return true', async () => {
+			const parsed = await fromCSV(csv)
+			const nature = inferColumnNature(parsed, 'US')
 			expect(nature).toBe(VariableNature.Binary)
 		})
 	})
@@ -75,11 +66,9 @@ describe('Infer column nature tests', () => {
 			flag: 'r',
 		})
 
-		const parsed = fromCSV(csv)
-
-		const nature = inferColumnNature(parsed, 'Close')
-
-		it('should return true', () => {
+		it('should return true', async () => {
+			const parsed = await fromCSV(csv)
+			const nature = inferColumnNature(parsed, 'Close')
 			expect(nature).toBe(VariableNature.Continuous)
 		})
 	})

--- a/javascript/tables/src/__tests__/unapplyCodebook.spec.ts
+++ b/javascript/tables/src/__tests__/unapplyCodebook.spec.ts
@@ -18,17 +18,15 @@ describe('unapply codebook tests', () => {
 			flag: 'r',
 		})
 
-		const parsed = fromCSV(csv, { autoType: false })
+		it('should return a column table', async () => {
+			const parsed = await fromCSV(csv, { autoType: false })
+			const codebookResult = await generateCodebook(parsed)
+			const resultTable = applyCodebook(
+				parsed,
+				codebookResult,
+				CodebookStrategy.DataTypeOnly,
+			)
 
-		const codebookResult = generateCodebook(parsed)
-
-		const resultTable = applyCodebook(
-			parsed,
-			codebookResult,
-			CodebookStrategy.DataTypeOnly,
-		)
-
-		it('should return a column table', () => {
 			expect(resultTable.numRows()).toBe(10)
 			expect(resultTable.numCols()).toBe(8)
 		})
@@ -40,41 +38,40 @@ describe('unapply codebook tests', () => {
 			flag: 'r',
 		})
 
-		const parsed = fromCSV(csv, { autoType: false })
+		it('should return a column table with mapping values', async () => {
+			const parsed = await fromCSV(csv, { autoType: false })
 
-		const codebookResult = generateCodebook(parsed)
+			const codebookResult = await generateCodebook(parsed)
 
-		const element = codebookResult.fields.find(
-			(element) => element.name === 'diagnosis',
-		)
-		const mappingElements: Record<number, string> = {
-			0: 'heart disease',
-			1: 'diabetes type I',
-			2: 'diabetes type II',
-			3: 'diabetes type III',
-		}
+			const element = codebookResult.fields.find(
+				(element) => element.name === 'diagnosis',
+			)
+			const mappingElements: Record<number, string> = {
+				0: 'heart disease',
+				1: 'diabetes type I',
+				2: 'diabetes type II',
+				3: 'diabetes type III',
+			}
 
-		element.mapping = mappingElements
+			if (element) element.mapping = mappingElements
 
-		const element2 = codebookResult.fields.find(
-			(element) => element.name === 'test',
-		)
-		const mappingElements2: Record<number, string> = {
-			0: 'Test1',
-			1: 'Test2',
-			2: 'Test3',
-			3: 'Test4',
-		}
+			const element2 = codebookResult.fields.find(
+				(element) => element.name === 'test',
+			)
+			const mappingElements2: Record<number, string> = {
+				0: 'Test1',
+				1: 'Test2',
+				2: 'Test3',
+				3: 'Test4',
+			}
 
-		element2.mapping = mappingElements2
+			if (element2) element2.mapping = mappingElements2
 
-		const resultTable = unapplyCodebook(
-			parsed,
-			codebookResult,
-			CodebookStrategy.DataTypeAndMapping,
-		)
-
-		it('should return a column table with mapping values', () => {
+			const resultTable = unapplyCodebook(
+				parsed,
+				codebookResult,
+				CodebookStrategy.DataTypeAndMapping,
+			)
 			expect(resultTable.numRows()).toBe(7)
 			expect(resultTable.numCols()).toBe(3)
 			expect(resultTable.get('diagnosis', 0)).toBe('0')

--- a/javascript/tables/src/__tests__/validateTable.spec.ts
+++ b/javascript/tables/src/__tests__/validateTable.spec.ts
@@ -88,7 +88,7 @@ describe('validate table', () => {
 	describe('minLength constraint', () => {
 		const codebook = createCodebook(companies, { Name: { minLength: 6 } })
 
-		it('without indexes',async () => {
+		it('without indexes', async () => {
 			const result = validateTable(await companies, await codebook)
 			expect(result.errors).toHaveLength(1)
 			expect(result.errors[0]?.name).toBe('Name')
@@ -108,7 +108,7 @@ describe('validate table', () => {
 	describe('maxLength constraint', () => {
 		const codebook = createCodebook(companies, { Name: { maxLength: 5 } })
 
-		it('without indexes',async () => {
+		it('without indexes', async () => {
 			const result = validateTable(await companies, await codebook)
 			expect(result.errors).toHaveLength(1)
 			expect(result.errors[0]?.name).toBe('Name')
@@ -116,7 +116,7 @@ describe('validate table', () => {
 			expect(result.errors[0]?.indexes).toBeUndefined()
 		})
 
-		it('with indexes', async() => {
+		it('with indexes', async () => {
 			const result = validateTable(await companies, await codebook, true)
 			expect(result.errors).toHaveLength(1)
 			expect(result.errors[0]?.name).toBe('Name')
@@ -132,7 +132,7 @@ describe('validate table', () => {
 	describe('minimum constraint', () => {
 		const codebook = createCodebook(companies, { ID: { minimum: 2 } })
 
-		it('without indexes', async() => {
+		it('without indexes', async () => {
 			const result = validateTable(await companies, await codebook)
 			expect(result.errors).toHaveLength(1)
 			expect(result.errors[0]?.name).toBe('ID')

--- a/javascript/tables/src/__tests__/validateTable.spec.ts
+++ b/javascript/tables/src/__tests__/validateTable.spec.ts
@@ -13,11 +13,11 @@ import { generateCodebook } from '../generateCodebook.js'
 import { validateTable } from '../validateTable.js'
 
 // generates the default codebook for a table and then applies constraints we want to test
-function createCodebook(
-	table: ColumnTable,
+async function createCodebook(
+	table: Promise<ColumnTable>,
 	constraints: Record<string, Constraints>,
-): CodebookSchema {
-	const codebook = generateCodebook(table)
+): Promise<CodebookSchema> {
+	const codebook = await generateCodebook(await table)
 	Object.keys(constraints).forEach((fieldName) => {
 		const found = codebook.fields.find((field) => field.name === fieldName)
 		if (found != null) {
@@ -46,16 +46,16 @@ describe('validate table', () => {
 	describe('required constraint', () => {
 		const codebook = createCodebook(companies2, { US: { required: true } })
 
-		it('without indexes', () => {
-			const result = validateTable(companies2, codebook)
+		it('without indexes', async () => {
+			const result = validateTable(await companies2, await codebook)
 			expect(result.errors).toHaveLength(1)
 			expect(result.errors[0]?.name).toBe('US')
 			expect(result.errors[0]?.rule).toBe(ErrorCode.Required)
 			expect(result.errors[0]?.indexes).toBeUndefined()
 		})
 
-		it('with indexes', () => {
-			const result = validateTable(companies2, codebook, true)
+		it('with indexes', async () => {
+			const result = validateTable(await companies2, await codebook, true)
 			expect(result.errors).toHaveLength(1)
 			expect(result.errors[0]?.name).toBe('US')
 			expect(result.errors[0]?.rule).toBe(ErrorCode.Required)
@@ -67,15 +67,15 @@ describe('validate table', () => {
 	describe('unique constraint', () => {
 		const codebook = createCodebook(companies, { US: { unique: true } })
 
-		it('without indexes', () => {
-			const result = validateTable(companies, codebook)
+		it('without indexes', async () => {
+			const result = validateTable(await companies, await codebook)
 			expect(result.errors).toHaveLength(1)
 			expect(result.errors[0]?.name).toBe('US')
 			expect(result.errors[0]?.rule).toBe(ErrorCode.Unique)
 		})
 
-		it('with indexes', () => {
-			const result = validateTable(companies, codebook, true)
+		it('with indexes', async () => {
+			const result = validateTable(await companies, await codebook, true)
 			expect(result.errors).toHaveLength(1)
 			expect(result.errors[0]?.name).toBe('US')
 			expect(result.errors[0]?.rule).toBe(ErrorCode.Unique)
@@ -88,16 +88,16 @@ describe('validate table', () => {
 	describe('minLength constraint', () => {
 		const codebook = createCodebook(companies, { Name: { minLength: 6 } })
 
-		it('without indexes', () => {
-			const result = validateTable(companies, codebook)
+		it('without indexes',async () => {
+			const result = validateTable(await companies, await codebook)
 			expect(result.errors).toHaveLength(1)
 			expect(result.errors[0]?.name).toBe('Name')
 			expect(result.errors[0]?.rule).toBe(ErrorCode.MinLength)
 			expect(result.errors[0]?.indexes).toBeUndefined()
 		})
 
-		it('with indexes', () => {
-			const result = validateTable(companies, codebook, true)
+		it('with indexes', async () => {
+			const result = validateTable(await companies, await codebook, true)
 			expect(result.errors).toHaveLength(1)
 			expect(result.errors[0]?.name).toBe('Name')
 			expect(result.errors[0]?.rule).toBe(ErrorCode.MinLength)
@@ -108,16 +108,16 @@ describe('validate table', () => {
 	describe('maxLength constraint', () => {
 		const codebook = createCodebook(companies, { Name: { maxLength: 5 } })
 
-		it('without indexes', () => {
-			const result = validateTable(companies, codebook)
+		it('without indexes',async () => {
+			const result = validateTable(await companies, await codebook)
 			expect(result.errors).toHaveLength(1)
 			expect(result.errors[0]?.name).toBe('Name')
 			expect(result.errors[0]?.rule).toBe(ErrorCode.MaxLength)
 			expect(result.errors[0]?.indexes).toBeUndefined()
 		})
 
-		it('with indexes', () => {
-			const result = validateTable(companies, codebook, true)
+		it('with indexes', async() => {
+			const result = validateTable(await companies, await codebook, true)
 			expect(result.errors).toHaveLength(1)
 			expect(result.errors[0]?.name).toBe('Name')
 			expect(result.errors[0]?.rule).toBe(ErrorCode.MaxLength)
@@ -132,16 +132,16 @@ describe('validate table', () => {
 	describe('minimum constraint', () => {
 		const codebook = createCodebook(companies, { ID: { minimum: 2 } })
 
-		it('without indexes', () => {
-			const result = validateTable(companies, codebook)
+		it('without indexes', async() => {
+			const result = validateTable(await companies, await codebook)
 			expect(result.errors).toHaveLength(1)
 			expect(result.errors[0]?.name).toBe('ID')
 			expect(result.errors[0]?.rule).toBe(ErrorCode.Minimum)
 			expect(result.errors[0]?.indexes).toBeUndefined()
 		})
 
-		it('with indexes', () => {
-			const result = validateTable(companies, codebook, true)
+		it('with indexes', async () => {
+			const result = validateTable(await companies, await codebook, true)
 			expect(result.errors).toHaveLength(1)
 			expect(result.errors[0]?.name).toBe('ID')
 			expect(result.errors[0]?.rule).toBe(ErrorCode.Minimum)
@@ -153,16 +153,16 @@ describe('validate table', () => {
 	describe('maximum constraint', () => {
 		const codebook = createCodebook(companies, { ID: { maximum: 2 } })
 
-		it('without indexes', () => {
-			const result = validateTable(companies, codebook)
+		it('without indexes', async () => {
+			const result = validateTable(await companies, await codebook)
 			expect(result.errors).toHaveLength(1)
 			expect(result.errors[0]?.name).toBe('ID')
 			expect(result.errors[0]?.rule).toBe(ErrorCode.Maximum)
 			expect(result.errors[0]?.indexes).toBeUndefined()
 		})
 
-		it('with indexes', () => {
-			const result = validateTable(companies, codebook, true)
+		it('with indexes', async () => {
+			const result = validateTable(await companies, await codebook, true)
 			expect(result.errors).toHaveLength(1)
 			expect(result.errors[0]?.name).toBe('ID')
 			expect(result.errors[0]?.rule).toBe(ErrorCode.Maximum)
@@ -178,16 +178,16 @@ describe('validate table', () => {
 			Name: { enum: ['Microsoft', 'Apple', 'Google'] },
 		})
 
-		it('without indexes', () => {
-			const result = validateTable(companies, codebook)
+		it('without indexes', async () => {
+			const result = validateTable(await companies, await codebook)
 			expect(result.errors).toHaveLength(1)
 			expect(result.errors[0]?.name).toBe('Name')
 			expect(result.errors[0]?.rule).toBe(ErrorCode.Enum)
 			expect(result.errors[0]?.indexes).toBeUndefined()
 		})
 
-		it('with indexes', () => {
-			const result = validateTable(companies, codebook, true)
+		it('with indexes', async () => {
+			const result = validateTable(await companies, await codebook, true)
 			expect(result.errors).toHaveLength(1)
 			expect(result.errors[0]?.name).toBe('Name')
 			expect(result.errors[0]?.rule).toBe(ErrorCode.Enum)
@@ -200,16 +200,16 @@ describe('validate table', () => {
 	describe('pattern constraint', () => {
 		const codebook = createCodebook(companies, { Name: { pattern: 'Ama*' } })
 
-		it('without indexes', () => {
-			const result = validateTable(companies, codebook)
+		it('without indexes', async () => {
+			const result = validateTable(await companies, await codebook)
 			expect(result.errors).toHaveLength(1)
 			expect(result.errors[0]?.name).toBe('Name')
 			expect(result.errors[0]?.rule).toBe(ErrorCode.Pattern)
 			expect(result.errors[0]?.indexes).toBeUndefined()
 		})
 
-		it('with indexes', () => {
-			const result = validateTable(companies, codebook, true)
+		it('with indexes', async () => {
+			const result = validateTable(await companies, await codebook, true)
 			expect(result.errors).toHaveLength(1)
 			expect(result.errors[0]?.name).toBe('Name')
 			expect(result.errors[0]?.rule).toBe(ErrorCode.Pattern)
@@ -222,13 +222,13 @@ describe('validate table', () => {
 	})
 
 	describe('multiple constraints', () => {
-		it('all fields have errors', () => {
+		it('all fields have errors', async () => {
 			const codebook = createCodebook(companies, {
 				ID: { required: true, unique: true, minimum: 3 },
 				Name: { enum: ['Microsoft', 'Apple', 'Google'], maxLength: 5 },
 			})
 
-			const result = validateTable(companies, codebook)
+			const result = validateTable(await companies, await codebook)
 			expect(result.errors).toHaveLength(3)
 			expect(result.errors[0]?.name).toBe('ID')
 			expect(result.errors[0]?.rule).toBe(ErrorCode.Minimum)
@@ -238,13 +238,13 @@ describe('validate table', () => {
 			expect(result.errors[2]?.rule).toBe(ErrorCode.Enum)
 		})
 
-		it('mixed errors', () => {
-			const codebook = createCodebook(companies, {
+		it('mixed errors', async () => {
+			const codebook = await createCodebook(companies, {
 				ID: { required: true, unique: true, minimum: 1, maximum: 5 },
 				Name: { enum: ['Microsoft', 'Apple', 'Google'], maxLength: 5 },
 			})
 
-			const result = validateTable(companies, codebook)
+			const result = validateTable(await companies, codebook)
 			expect(result.errors).toHaveLength(2)
 			expect(result.errors[0]?.name).toBe('Name')
 			expect(result.errors[0]?.rule).toBe(ErrorCode.MaxLength)
@@ -252,14 +252,14 @@ describe('validate table', () => {
 			expect(result.errors[1]?.rule).toBe(ErrorCode.Enum)
 		})
 
-		it('no fields have errors', () => {
-			const codebook = createCodebook(companies, {
+		it('no fields have errors', async () => {
+			const codebook = await createCodebook(companies, {
 				ID: { required: true, unique: true, minimum: 1, maximum: 5 },
 				Name: { maxLength: 10 },
 				Employees: { minimum: 1000 },
 			})
 
-			const result = validateTable(companies, codebook)
+			const result = validateTable(await companies, codebook)
 			expect(result.errors).toHaveLength(0)
 		})
 	})

--- a/javascript/tables/src/fromCSV.ts
+++ b/javascript/tables/src/fromCSV.ts
@@ -15,20 +15,20 @@ import { readCsvTable } from './readCsvTable.js'
  * Meant for quick-and-dirty reads, with the advantage that our default parsing aligns with pandas.
  * Use readTable for more control over schema options and formats.
  */
-export function fromCSV(
+export async function fromCSV(
 	text: string,
 	options: CSVParseOptions = {
 		autoType: true,
 		autoMax: Infinity,
 	},
-): ColumnTable {
+): Promise<ColumnTable> {
 	const { autoType, autoMax, ...rest } = options
 
 	const csv = readCsvTable(text, {
 		parser: rest,
 	})
 	if (options?.autoType) {
-		const codebook = generateCodebook(csv, options)
+		const codebook = await generateCodebook(csv, options)
 		return applyCodebook(csv, codebook, CodebookStrategy.DataTypeOnly)
 	}
 	return csv

--- a/javascript/tables/src/parseTypes.ts
+++ b/javascript/tables/src/parseTypes.ts
@@ -119,7 +119,7 @@ export function parseArray(
 		}
 
 		// NOTE: Array.isArray won't return true on typed arrays (e.g. Float64Array)
-		// We could check for each typed array type, but that's a lot of cases. 
+		// We could check for each typed array type, but that's a lot of cases.
 		// Instead, we'll just check to see if this is a string, and if so, parse the array out.
 		const array = typeof value === 'string' ? value.split(delimiter) : value
 

--- a/javascript/tables/src/parseTypes.ts
+++ b/javascript/tables/src/parseTypes.ts
@@ -117,7 +117,12 @@ export function parseArray(
 		if (isNull(value)) {
 			return null
 		}
-		const array = value.split(delimiter) as any[]
+
+		// NOTE: Array.isArray won't return true on typed arrays (e.g. Float64Array)
+		// We could check for each typed array type, but that's a lot of cases. 
+		// Instead, we'll just check to see if this is a string, and if so, parse the array out.
+		const array = typeof value === 'string' ? value.split(delimiter) : value
+
 		try {
 			const parsed = array.map((i) => {
 				const item = `${i}`

--- a/javascript/tables/src/util.ts
+++ b/javascript/tables/src/util.ts
@@ -16,8 +16,8 @@ import toNumber from 'lodash-es/toNumber.js'
  * but if we remove them all even in invalid cases (e.g., '1,00'), invalid
  * numbers could be parsed downstream as valid.
  * The same occurs with decimal separators: parseFloat will ignore anything after the first.
- * @param value
- * @param options
+ * @param value - the value to format
+ * @param options - formatting options
  * @returns
  */
 export function formatNumberStr(

--- a/javascript/tables/src/validateTable.ts
+++ b/javascript/tables/src/validateTable.ts
@@ -22,8 +22,8 @@ import {
 
 /**
  * Validates an entire table against a codebook's Field constraints.
- * @param table
- * @param codebook
+ * @param table - the table to validate
+ * @param codebook - the codebook to use
  * @param includeIndexes - indicate whether to include the indexes of the rows that failed validation for each field
  * @returns
  */
@@ -46,10 +46,10 @@ export function validateTable(
 
 /**
  * Validates a column against a Field definition's constraints.
- * @param table
- * @param name
- * @param dataType
- * @param constraints
+ * @param table - the table to validate 
+ * @param name - the name of the column
+ * @param dataType - the type of the column
+ * @param constraints - the field constraints to validate against
  * @param includeIndexes - indicate whether to include the indexes of the row instances that failed validation
  * @returns
  */

--- a/javascript/tables/src/validateTable.ts
+++ b/javascript/tables/src/validateTable.ts
@@ -46,7 +46,7 @@ export function validateTable(
 
 /**
  * Validates a column against a Field definition's constraints.
- * @param table - the table to validate 
+ * @param table - the table to validate
  * @param name - the name of the column
  * @param dataType - the type of the column
  * @param constraints - the field constraints to validate against


### PR DESCRIPTION
![Screenshot 2023-06-23 at 12 22 38 PM](https://github.com/microsoft/datashaper/assets/113544/d480ef26-428a-42d9-9cad-e644bb5a6f55)

With some larger datasets (~20MB arrow), the `generateCodebook` process takes a long time due to the multiple full-table scans it performs to guess the types of each column. This PR makes `generateCodebook` async, and adds some feedback callbacks to it's signature. 

This allows us to update the ImportTable component with a progressbar and some details on what work is happening during import (e.g. infer typing on column X).

Additionally, resolved some error conditions when using datasets with typed arrays.