### PR TITLE
fix nhefs url

### DIFF
--- a/javascript/utilities/src/common/__tests__/FileCollection.test.ts
+++ b/javascript/utilities/src/common/__tests__/FileCollection.test.ts
@@ -68,7 +68,7 @@ describe('FileCollection.add', () => {
 
 	it('should add a file from a url to the FileCollection', async () => {
 		await fileCollection.add(
-			'https://cdn1.sph.harvard.edu/wp-content/uploads/sites/1268/1268/20/nhefs.csv',
+			'https://raw.githubusercontent.com/BiomedSciAI/causallib/master/causallib/datasets/data/nhefs/NHEFS.csv',
 		)
 		expect(fileCollection.list()).toHaveLength(1)
 	})

--- a/javascript/utilities/src/common/__tests__/FileCollection.test.ts
+++ b/javascript/utilities/src/common/__tests__/FileCollection.test.ts
@@ -68,7 +68,7 @@ describe('FileCollection.add', () => {
 
 	it('should add a file from a url to the FileCollection', async () => {
 		await fileCollection.add(
-			'https://raw.githubusercontent.com/BiomedSciAI/causallib/master/causallib/datasets/data/nhefs/NHEFS.csv',
+			'https://cdn1.sph.harvard.edu/wp-content/uploads/sites/1268/1268/20/nhefs.csv',
 		)
 		expect(fileCollection.list()).toHaveLength(1)
 	})

--- a/javascript/webapp/public/examples/smoking.json
+++ b/javascript/webapp/public/examples/smoking.json
@@ -10,7 +10,7 @@
 					"profile": "datatable",
 					"title": "nhefs.csv",
 					"name": "datatable.json",
-					"path": "https://cdn1.sph.harvard.edu/wp-content/uploads/sites/1268/1268/20/nhefs.csv",
+					"path": "https://raw.githubusercontent.com/BiomedSciAI/causallib/master/causallib/datasets/data/nhefs/NHEFS.csv",
 					"metadata": {
 						"source": "https://www.hsph.harvard.edu/miguel-hernan/causal-inference-book/",
 						"citation": "Hernán MA, Robins JM (2020). Causal Inference: What If. Boca Raton: Chapman & Hall/CRC"

--- a/schema/fixtures/datapackages/nhefs-embedded/datapackage.json
+++ b/schema/fixtures/datapackages/nhefs-embedded/datapackage.json
@@ -10,7 +10,7 @@
 					"rel": "input",
 					"$schema": "https://microsoft.github.io/datashaper/schema/datatable/v1.json",
 					"profile": "datatable",
-					"path": "https://cdn1.sph.harvard.edu/wp-content/uploads/sites/1268/1268/20/nhefs.csv",
+					"path": "https://raw.githubusercontent.com/BiomedSciAI/causallib/master/causallib/datasets/data/nhefs/NHEFS.csv",
 					"format": "csv",
 					"layout": "micro"
 				},


### PR DESCRIPTION
- problems with Harvard cdn cors url
- changed to a [BiomedSciAI github host](https://raw.githubusercontent.com/BiomedSciAI/causallib/master/causallib/datasets/data/nhefs/NHEFS.csv) 