### PR TITLE
Update `derive_from_rows` to take a Table as input

### DIFF
--- a/python/datashaper/datashaper/execution/derive_from_rows.py
+++ b/python/datashaper/datashaper/execution/derive_from_rows.py
@@ -2,8 +2,8 @@ from typing import Callable, TypeVar
 
 import pandas as pd
 
-from ..engine import VerbInput
 from ..progress import StatusReportHandler, progress_callback
+from ..table_store import Table
 from .utils import transform_pandas_table
 
 
@@ -11,14 +11,14 @@ ItemType = TypeVar("ItemType")
 
 
 def derive_from_rows(
-    input: VerbInput,
+    input: Table,
     reporter: StatusReportHandler,
     transform: Callable[[pd.Series], ItemType],
     num_threads: int = 4,
     stagger: int = 0,
 ) -> list[ItemType]:
     """Apply a generic transform function to each row. Any errors will be reported and thrown."""
-    output = input.get_input().copy()
+    output = input.copy()
     total_rows = len(output)
 
     results, errors = transform_pandas_table(

--- a/python/datashaper/pyproject.toml
+++ b/python/datashaper/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "datashaper"
-version = "0.0.9"
+version = "0.0.10"
 description = "This project provides a collection of utilities for doing lightweight data wrangling."
 authors = [
     "Nathan Evans <naevans@microsoft.com>",

--- a/python/datashaper/tests/test_workflow.py
+++ b/python/datashaper/tests/test_workflow.py
@@ -452,7 +452,7 @@ def create_parallel_transforming_verb():
             row["b"] = row["a"] + 1
             return row
 
-        results = derive_from_rows(input, reporter, transform_row)
+        results = derive_from_rows(input.get_input(), reporter, transform_row)
 
         return TableContainer(table=pd.DataFrame(results))
 
@@ -464,7 +464,7 @@ def create_parallel_transforming_verb_throwing():
         def transform_row(row: pd.Series):
             raise ValueError("oh no, this should be expected")
 
-        results = derive_from_rows(input, reporter, transform_row)
+        results = derive_from_rows(input.get_input(), reporter, transform_row)
 
         return TableContainer(table=pd.DataFrame(results))
 


### PR DESCRIPTION
Using `VerbInput` as input assumes a bit much in this helper, using the actual required type instead.