### PR TITLE
Function to load verbs instead of writing all the imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,25 @@ Core verbs are built into the toolkit, and should generally have JavaScript and 
 1. Schema definition - this is done by authoring TypeScript types in the [javascript/schema](./javascript/schema/) folder, which are then generated as JSONSchema during a build step.
 2. Cross-platform tests - these are defined in [schema/fixtures](./schema/fixtures), primarily in the workflow folder. Each fixture includes a workflow.json and an expected output csv file. Executors run in both JavaScript and Python to confirm that outputs match the expected table.
 3. JavaScript implementation - verbs are implemented in [javascript/workflow/verbs](./javascript/workflow/src/verbs/)
-4. Python implementation - verbs are implemented in [python/verbs](./python/datashaper/datashaper/engine/verbs/)
-5. Verb UX - individual verb UX components are in [javascript/react](./javascript/react/src/components/verbs/)
+4. Verb UX - individual verb UX components are in [javascript/react](./javascript/react/src/components/verbs/)
+
+#### Python implementation
+1. Verbs are implemented in [python/verbs](./python/datashaper/datashaper/engine/verbs/)
+2. Create a verb file following the json schema as package structure, for example, if in the schema the verbs is defined as:
+```json
+"verb": {
+    "const": "strings.upper",
+    "type": "string"
+}
+```
+The location of the verb must be in [datashaper.engine.verbs.strings.upper](./python/datashaper/datashaper/engine/verbs/strings/upper.py).
+
+3. Create a function that replicates the same functionality as the javascript version and use the `@verb` decorator to make it available to the Workflow engine. The `name` parameter of the decorator must match the package name defined in the schema. For example:
+```python
+@verb(name="strings.upper")
+def upper(input: VerbInput, column: str, to: str):
+    ...
+```
 
 ### Custom verbs
 

--- a/python/datashaper/datashaper/engine/verbs/__init__.py
+++ b/python/datashaper/datashaper/engine/verbs/__init__.py
@@ -1,87 +1,30 @@
-from .aggregate import aggregate
-from .bin import bin
-from .binarize import binarize
-from .boolean import boolean
-from .concat import concat
-from .convert import convert
-from .copy import copy
-from .dedupe import dedupe
-from .derive import derive
-from .difference import difference
-from .drop import drop
-from .erase import erase
-from .fill import fill
-from .filter import filter
-from .fold import fold
-from .groupby import groupby
-from .impute import impute
-from .intersect import intersect
-from .join import join
-from .lookup import lookup
-from .merge import merge
-from .onehot import onehot
-from .orderby import orderby
-from .pivot import pivot
-from .recode import recode
-from .rename import rename
-from .rollup import rollup
-from .sample import sample
-from .select import select
-from .spread import spread
-from .strings import lower, replace, upper
-from .unfold import unfold
-from .ungroup import ungroup
-from .unhot import unhot
-from .union import union
-from .unorder import unorder
-from .unroll import unroll
+import importlib
+import importlib.util
+import os
+import pkgutil
+
 from .verb_input import VerbInput
-from .verbs_mapping import VerbManager, verb
-from .window import window
+from .verbs_mapping import VerbManager
 
 
-__all__ = [
-    "lower",
-    "upper",
-    "replace",
-    "aggregate",
-    "bin",
-    "binarize",
-    "boolean",
-    "concat",
-    "convert",
-    "copy",
-    "dedupe",
-    "derive",
-    "difference",
-    "drop",
-    "erase",
-    "fill",
-    "filter",
-    "fold",
-    "groupby",
-    "impute",
-    "intersect",
-    "join",
-    "lookup",
-    "merge",
-    "onehot",
-    "orderby",
-    "pivot",
-    "recode",
-    "rename",
-    "rollup",
-    "sample",
-    "select",
-    "spread",
-    "unfold",
-    "ungroup",
-    "unhot",
-    "union",
-    "unorder",
-    "unroll",
-    "VerbInput",
-    "VerbManager",
-    "verb",
-    "window",
-]
+def load_verbs(module_path: str, module_name: str):
+    """
+    Loads the verbs from the given module path recursively.
+    This is useful to run all the @verb decorators and register the verbs in the verb manager.
+    """
+    for _, sub_module, is_module in pkgutil.iter_modules([module_path]):
+        if not is_module:
+            full_path = os.path.join(module_path, f"{sub_module}.py")
+            module = importlib.util.spec_from_file_location(module_name, full_path)
+            module_to_load = f"{module.name}.{sub_module}"
+            importlib.import_module(module_to_load)
+        else:
+            full_path = os.path.join(module_path, sub_module)
+            sub_module_name = f"{__name__}.{sub_module}"
+            load_verbs(full_path, sub_module_name)
+
+
+load_verbs(os.path.dirname(__file__), __name__)
+
+
+__all__ = ["VerbInput", "VerbManager", "load_verbs"]

--- a/python/datashaper/datashaper/engine/verbs/verbs_mapping.py
+++ b/python/datashaper/datashaper/engine/verbs/verbs_mapping.py
@@ -28,13 +28,16 @@ class VerbManager:
     verbs: dict[str, Callable] = field(default_factory=dict)
 
     def __getitem__(self, verb: str) -> Callable[..., TableContainer]:
-        return self.verbs[verb]
+        return self.get_verb(verb)
 
     def __contains__(self, verb: str) -> bool:
         return verb in self.verbs
 
     def register_verbs(self, verbs: dict[str, Callable]):
         self.verbs.update(verbs)
+
+    def get_verb(self, verb: str) -> Callable[..., TableContainer]:
+        return self.verbs[verb]
 
     @classmethod
     @cache

--- a/python/datashaper/tests/verbs/sample_test.py
+++ b/python/datashaper/tests/verbs/sample_test.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from datashaper.engine.verbs import VerbInput, sample
+from datashaper.engine.verbs import VerbInput, VerbManager
 from datashaper.table_store import TableContainer
 
 
@@ -12,6 +12,7 @@ def make_verb_input(data: list, columns: list[str]):
 
 def test_sample():
     verb_input = make_verb_input([[1], [2], [3], [4], [5]], ["id"])
+    sample = VerbManager.get().get_verb("sample")
     output = sample(input=verb_input, size=2)
     assert len(output.table) == 2
 
@@ -21,6 +22,7 @@ def test_sample_seed():
 
     values = None
     for i in range(0, 10):
+        sample = VerbManager.get().get_verb("sample")
         output = sample(input=verb_input, size=2, seed=0xBEEF)
         ids = output.table["id"].values
 


### PR DESCRIPTION
Proposal to have a function that loads all the verbs/**/*.py files to find `@verb` decorator and populate the VerbManager (this also removes the verbs from the public API and make them only accessible through the VerbManager)